### PR TITLE
Install gems readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cap rvm1:install:gems
 
 Or add an before hook:
 ```ruby
-before 'deploy', 'rvm1:install:gems'  # install/update gems
+before 'deploy', 'rvm1:install:gems'  # install/update gems from Gemfile into gemset
 ```
 
 Right now all gems in Gemfile will be installed into gemset.


### PR DESCRIPTION
Under the "install gems" section, it looks like there was a typo for the line to be placed in the Capistrano file.
