### PR TITLE
[#18] Sanitize the environment of the new Ruby process.

### DIFF
--- a/script/rvm-auto.sh
+++ b/script/rvm-auto.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 
 # Prevent existing Ruby environment from affecting a new Ruby run via RVM.
+unset BUNDLE_BIN
 unset BUNDLE_BIN_PATH
+unset BUNDLE_FROZEN
 unset BUNDLE_GEMFILE
+unset BUNDLE_PATH
+unset BUNDLE_WITHOUT
+
 unset GEM_HOME
 unset GEM_PATH
 unset MY_RUBY_HOME


### PR DESCRIPTION
The new Ruby exec'd by RVM can be affected by existing environment variables.  Specifically, a
current Ruby process running with bundler may have "RUBYOPT=-rbundler/setup", which will cause
breakage if the bundle has not yet been installed a new Ruby.

Remove the variables to ensure independence and expected behaviour of the new Ruby.  Unset one at a
time for readbility.
