### PR TITLE
Fix for environment-specific application name

### DIFF
--- a/lib/rvm1/tasks/capistrano3.rake
+++ b/lib/rvm1/tasks/capistrano3.rake
@@ -40,12 +40,13 @@ namespace :load do
     set :rvm1_ruby_version, "."
     set :rvm1_map_bins, %w{rake gem bundle ruby}
 
-    temp_auto_script_path = "#{fetch(:tmp_dir)}/#{fetch(:application)}"
-    if fetch(:ssh_options) && fetch(:ssh_options)[:user]
-      temp_auto_script_path = "#{temp_auto_script_path}-#{fetch(:ssh_options)[:user]}"
-    end
-
-    set :rvm1_auto_script_path, temp_auto_script_path
+    set :rvm1_auto_script_path, -> { 
+      temp_auto_script_path = "#{fetch(:tmp_dir)}/#{fetch(:application)}"
+      if fetch(:ssh_options) && fetch(:ssh_options)[:user]
+        temp_auto_script_path = "#{temp_auto_script_path}-#{fetch(:ssh_options)[:user]}"
+      end
+      temp_auto_script_path
+    }
   end
 end
 


### PR DESCRIPTION
E.g. when you do `set :application, "..."` in `config/deploy/staging.rb`

When you have multiple projects on same server on different users it fails as it can't run `/tmp//rvm-auto.sh`
