### PR TITLE
add task to install bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ we will improve it with new RG releases.
 - RG 2.2 - limited support for `Gemfile.lock` - work still in progress,
   test with `rvm rubygems head`
 
+## Or using bundler
+
+If you want to use `bundler`,
+
+```bash
+cap rvm1:install:bundler
+```
+
+Or add an after hook:
+```ruby
+after 'rvm1:install:ruby', 'rvm1:install:bundler'  # install bundler
+```
+
 ## Configuration
 
 Well if you really need to there are available ways:

--- a/lib/rvm1/tasks/capistrano3/commands.rake
+++ b/lib/rvm1/tasks/capistrano3/commands.rake
@@ -33,6 +33,14 @@ namespace :rvm1 do
     before :gems, "deploy:updating"
     before :gems, 'rvm1:hook'
 
+    desc 'Install bundler'
+    task :bundler do
+      on roles(fetch(:rvm1_roles, :all)) do
+        within release_path do
+          execute :rvm, fetch(:rvm1_ruby_version), 'do', 'gem install bundler'
+        end
+      end
+    end
   end
 
   namespace :alias do


### PR DESCRIPTION
in many case, a lot of ruby codes depend on existence of `bundle` command as yet,
off cause I can't replace all gems to avoid `bundle` command,
so I want easy way to install `bundler`.