### PR TITLE
Passes rvm_path variable to install script in order to be able to do system installs

### DIFF
--- a/script/install-rvm.sh
+++ b/script/install-rvm.sh
@@ -11,7 +11,8 @@ mkdir "${CURL_HOME}/" &&
 exit $?
 
 # run the installer
-if \curl -L https://get.rvm.io -o rvm-installer.sh && bash rvm-installer.sh stable
+echo $rvm_path
+if \curl -L https://get.rvm.io -o rvm-installer.sh && bash rvm-installer.sh stable --path $rvm_path
 then __LAST_STATUS=0
 else __LAST_STATUS=$?
 fi


### PR DESCRIPTION
Hello,

I tried to do a system install with Capistrano 3 + rvm1-capistrano3. For this I checked the documentation where it states:

> fetch(:default_env).merge!( rvm_path: "/opt/rvm" ) - to force specific path to rvm installation

So, initially I did exactly that

`fetch(:default_env).merge!( rvm_path: "/usr/local/rvm" ) `

This did not work, so I tried setting default_env alone

`set :default_env, { rvm_path: "/usr/local/rvm" }`

But this gave me the same result when running `cap my_stage rvm1:install:rvm`

> 
> 03 Upgrading the RVM installation in /home/my_user/.rvm/
> 03     RVM PATH line found in /home/my_user/.mkshrc /home/my_user/.profile /home/my_user/.zshrc.
> 03     RVM PATH line not found for Bash, rerun this command with '--auto-dotfiles' flag to fix it.
> 03     RVM sourcing line found in /home/my_user/.profile /home/my_user/.zlogin.
> 03     RVM sourcing line not found for Bash, rerun this command with '--auto-dotfiles' flag to fix it.
> 03 Upgrade of RVM in /home/my_user/.rvm/ is complete.

Notice the last line of the log above.

So I checked the rvm-install.sh script and saw that we are not passing the path variable to the original RVM script that is downloaded in the previous step. 

Hence, this PR. 

I hope this makes sense, as I am rather new to Capistrano3.

Cheers,
-Manuel