### PR TITLE
Add ruby install option config parameter

### DIFF
--- a/lib/rvm1/tasks/capistrano3.rake
+++ b/lib/rvm1/tasks/capistrano3.rake
@@ -38,6 +38,7 @@ end
 namespace :load do
   task :defaults do
     set :rvm1_ruby_version, "."
+    set :rvm1_ruby_install_options, []
     set :rvm1_map_bins,   -> { fetch(:rvm_map_bins, %w{rake gem bundle ruby}) }
     set :rvm1_alias_name, -> { fetch(:application) }
     set :rvm1_auto_script_path, -> { "#{fetch(:deploy_to)}/rvm1scripts" }

--- a/lib/rvm1/tasks/capistrano3/commands.rake
+++ b/lib/rvm1/tasks/capistrano3/commands.rake
@@ -15,7 +15,7 @@ namespace :rvm1 do
     task :ruby do
       on roles(fetch(:rvm1_roles, :all)) do
         within fetch(:release_path) do
-          execute "#{fetch(:rvm1_auto_script_path)}/rvm-auto.sh", "rvm", "--install", "install", fetch(:rvm1_ruby_version)
+          execute "#{fetch(:rvm1_auto_script_path)}/rvm-auto.sh", "rvm", "--install", "install", fetch(:rvm1_ruby_version), *fetch(:rvm1_ruby_install_options, [])
         end
       end
     end


### PR DESCRIPTION
This config parameter allows user to set install options (such as `--patch` and `--32`) to customize ruby installation.
