### PR TITLE
Fix rvm_path variable handling for install error.

### DIFF
--- a/script/install-rvm.sh
+++ b/script/install-rvm.sh
@@ -11,8 +11,11 @@ mkdir "${CURL_HOME}/" &&
 exit $?
 
 # run the installer
-echo $rvm_path
-if \curl -L https://get.rvm.io -o rvm-installer.sh && bash rvm-installer.sh stable --path $rvm_path
+options=""
+if [ ! -z "$rvm_path" ]; then
+  options="--path '$rvm_path'"
+fi
+if \curl -L https://get.rvm.io -o rvm-installer.sh && bash rvm-installer.sh stable $options
 then __LAST_STATUS=0
 else __LAST_STATUS=$?
 fi


### PR DESCRIPTION
With current version of rvm installer fails with following message if user do not set `rvm_path` environment.
    
```
ERROR: --path must be followed by a path.
```
    
This patch fixes option handling with `rvm_path` environment variable.
User can ommit the setting if they'd like to install rvm default location.