### PR TITLE
Autodetect rvm path in mixed mode installation

### DIFF
--- a/script/rvm-auto.sh
+++ b/script/rvm-auto.sh
@@ -39,6 +39,8 @@ then
   then rvm_path="$HOME/.rvm"
   elif test -x  "/usr/local/rvm/bin/rvm"
   then rvm_path="/usr/local/rvm"
+  elif test -x  "/usr/share/rvm/bin/rvm"
+  then rvm_path="/usr/share/rvm"
   else rvm_path="$HOME/.rvm"
   fi
 fi


### PR DESCRIPTION
[RVM package for Ubuntu](https://github.com/rvm/ubuntu_rvm) installs rvm into /usr/share/rvm (as Debian/Ubuntu convention). In this case rvm1-capistrano3 fails to autodetect rvm. Setting rvm_path also does not work.

Fix is to add /usr/share/rvm path in autodetect script